### PR TITLE
#12 copy kube-proxy nodeport fix to support virtual ip

### DIFF
--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -50,6 +50,12 @@ func (f *fakePortOpener) OpenLocalPort(lp *util.LocalPort) (util.Closeable, erro
 	return nil, nil
 }
 
+type fakeNodeIP struct{}
+
+func (f *fakeNodeIP) GetNodeIPs(ipvs utilipvs.Interface) ([]net.IP, error){
+	ips := []net.IP{net.ParseIP("100.101.102.103")}
+	return ips, nil
+}
 
 func makeTestService(namespace, name string, svcFunc func(*api.Service)) *api.Service {
 	svc := &api.Service{
@@ -150,6 +156,7 @@ func NewFakeProxier() *Proxier{
 		clusterCIDR:       "10.0.0.0/24",
 		hostname:          testHostname,
 		nodeIPs:           nodeIPs,
+		nodeIPInterface:   &fakeNodeIP{},
 		exec:              &fakeexec.FakeExec{},
 		scheduler:         utilipvs.DEFAULSCHE,
 		ipvsInterface:     ipvs,

--- a/pkg/util/ipvs/testing/fake.go
+++ b/pkg/util/ipvs/testing/fake.go
@@ -9,6 +9,7 @@ import (
 	utilipvs "kube-enn-proxy/pkg/util/ipvs"
 	libipvs "github.com/docker/libnetwork/ipvs"
 	"github.com/vishvananda/netlink"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type ServiceKey struct {
@@ -219,6 +220,11 @@ func (f *Faker) ListDuumyClusterIp(link netlink.Link) ([]netlink.Addr, error){
 		addrs = append(addrs,vip)
 	}
 	return addrs, nil
+}
+
+func (f *Faker) GetLocalAddresses(Dev string) (sets.String, error) {
+
+	return nil, nil
 }
 
 func ToProtocolNumber(str string) uint16{


### PR DESCRIPTION
just copy kube-proxy nodeport fix to support virtual ip
nodeport ip now from kernel local ip except ip with interface "lo" "docker" "enn-dummy" "flannel"